### PR TITLE
Fix max balance calculation bugs and add currency/UX clarity

### DIFF
--- a/app/account/[id]/AccountDetailPageHeading.tsx
+++ b/app/account/[id]/AccountDetailPageHeading.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useAccount } from "@/contexts/accountsContext";
+import { useBudgetState } from "@/contexts/budgetContext";
 import Heading1 from "@/design-system/headings/heading1/Heading1";
 
 export default function AccountDetailPageHeading({
@@ -9,9 +10,16 @@ export default function AccountDetailPageHeading({
   accountId: string;
 }) {
   const account = useAccount(accountId);
+  const { defaultBudgetCurrencyIsoCode } = useBudgetState();
+  const currencySuffix = defaultBudgetCurrencyIsoCode
+    ? ` (${defaultBudgetCurrencyIsoCode})`
+    : "";
   return (
     <div>
-      <Heading1>{account.name} - Details</Heading1>
+      <Heading1>
+        {account.name}
+        {currencySuffix} - Details
+      </Heading1>
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,15 +1,16 @@
 import Accounts from "@/components/Accounts";
-import DefaultBudgetIdFetcher from "@/components/DefaultBudgetIdFetcher";
+import DefaultBudgetFetcher from "@/components/DefaultBudgetFetcher";
 import Disclaimer from "@/components/Disclaimer";
 import YnabAuthorization from "@/components/YnabAuthorization";
+import Button from "@/design-system/button/Button";
 
 export default function Home() {
   const ynabAuthorizationUrl = `https://app.ynab.com/oauth/authorize?client_id=${process.env["YNAB_OATH_CLIENT_ID"]}&redirect_uri=${process.env["YNAB_OATH_REDIRECT_URI"]}&response_type=token`;
   return (
     <div>
       <YnabAuthorization />
-      <a href={ynabAuthorizationUrl}>Authorize With YNAB</a>
-      <DefaultBudgetIdFetcher />
+      <Button href={ynabAuthorizationUrl}>Authorize With YNAB</Button>
+      <DefaultBudgetFetcher />
       <Accounts />
       <Disclaimer />
     </div>

--- a/calculation-functions/getTransactionsWithBalances.test.ts
+++ b/calculation-functions/getTransactionsWithBalances.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { TransactionDetail, TransactionClearedStatus } from "ynab";
+import getTransactionsWithBalances from "./getTransactionsWithBalances";
+
+function makeTransaction(
+  partial: Partial<TransactionDetail> & { id: string; date: string; amount: number },
+): TransactionDetail {
+  return {
+    id: partial.id,
+    date: partial.date,
+    amount: partial.amount,
+    memo: partial.memo ?? "",
+    cleared: partial.cleared ?? TransactionClearedStatus.Cleared,
+    approved: partial.approved ?? true,
+    deleted: partial.deleted ?? false,
+    account_id: partial.account_id ?? "acct",
+    account_name: partial.account_name ?? "Account",
+    payee_name: partial.payee_name ?? null,
+    subtransactions: partial.subtransactions ?? [],
+  } as TransactionDetail;
+}
+
+describe("getTransactionsWithBalances", () => {
+  it("sorts ascending by date so the running balance is chronological even if the API returns newest first", () => {
+    const transactions = [
+      makeTransaction({ id: "b", date: "2024-06-01", amount: -200000 }),
+      makeTransaction({ id: "a", date: "2024-01-01", amount: 1000000 }),
+    ];
+
+    const result = getTransactionsWithBalances(transactions);
+
+    expect(result.map((t) => t.id)).toEqual(["a", "b"]);
+    expect(result.map((t) => t.balance)).toEqual([1000000, 800000]);
+  });
+
+  it("captures the intra-day peak when an inflow and outflow share a date (Wise scenario)", () => {
+    // YNAB does not expose intra-day timestamps. If a 5,000 EUR inflow and a
+    // 5,000 EUR outflow share a date, the API may return them in either order.
+    // Sorting inflows-first on a tie ensures the running balance reflects the
+    // day's peak (5,000) rather than a transient negative low.
+    const transactions = [
+      makeTransaction({ id: "outflow", date: "2024-03-15", amount: -5000000 }),
+      makeTransaction({ id: "inflow", date: "2024-03-15", amount: 5000000 }),
+    ];
+
+    const result = getTransactionsWithBalances(transactions);
+
+    expect(result.map((t) => t.id)).toEqual(["inflow", "outflow"]);
+    expect(result.map((t) => t.balance)).toEqual([5000000, 0]);
+    // The peak balance is captured in a transaction's post-balance.
+    expect(Math.max(...result.map((t) => t.balance))).toBe(5000000);
+  });
+
+  it("does not mutate the input array", () => {
+    const transactions = [
+      makeTransaction({ id: "b", date: "2024-06-01", amount: -200000 }),
+      makeTransaction({ id: "a", date: "2024-01-01", amount: 1000000 }),
+    ];
+    const originalOrder = transactions.map((t) => t.id);
+
+    getTransactionsWithBalances(transactions);
+
+    expect(transactions.map((t) => t.id)).toEqual(originalOrder);
+  });
+});

--- a/calculation-functions/getTransactionsWithBalances.ts
+++ b/calculation-functions/getTransactionsWithBalances.ts
@@ -4,21 +4,28 @@ import { TransactionDetail } from "ynab";
 export default function getTransactionsWithBalances(
   transactions: TransactionDetail[],
 ): TransactionWithBalance[] {
+  // YNAB's API only exposes a date (no timestamp) and does not document
+  // an order for same-date transactions. Sort ascending by date, and on a
+  // tie put inflows before outflows. This captures the day's peak balance
+  // in the post-transaction running balance, which the FBAR rules treat as
+  // a "reasonable approximation of the greatest value" for the calendar year.
+  const sorted = [...transactions].sort((a, b) => {
+    if (a.date !== b.date) {
+      return a.date < b.date ? -1 : 1;
+    }
+    return b.amount - a.amount;
+  });
+
   let runningBalance = 0;
-  const transactionsWithBalances = transactions.map(
-    ({ id, date, amount, memo, payee_name: payeeName }) => {
-      const currentBalance = runningBalance + amount;
-      const transactionWithBalance = {
-        id,
-        date,
-        amount,
-        memo,
-        payeeName,
-        balance: currentBalance,
-      };
-      runningBalance = currentBalance;
-      return transactionWithBalance;
-    },
-  );
-  return transactionsWithBalances;
+  return sorted.map(({ id, date, amount, memo, payee_name: payeeName }) => {
+    runningBalance += amount;
+    return {
+      id,
+      date,
+      amount,
+      memo,
+      payeeName,
+      balance: runningBalance,
+    };
+  });
 }

--- a/components/AccountTable.test.tsx
+++ b/components/AccountTable.test.tsx
@@ -2,14 +2,20 @@ import { describe, it, vi, expect } from "vitest";
 import { render, screen, within } from "@testing-library/react";
 import AccountTable from "./AccountTable";
 import { useSelectedAccounts } from "@/contexts/accountsContext";
+import { useBudgetState } from "@/contexts/budgetContext";
 import { mockSelectedAccounts } from "./AccountTable.test-data";
 
 vi.mock(import("@/contexts/accountsContext"));
+vi.mock(import("@/contexts/budgetContext"));
 
 describe("AccountTable", () => {
   it("dynamically adjusts to the years for which there are max balances", async () => {
     // arrange
     vi.mocked(useSelectedAccounts).mockReturnValue(mockSelectedAccounts);
+    vi.mocked(useBudgetState).mockReturnValue({
+      defaultBudgetId: "budget-1",
+      defaultBudgetCurrencyIsoCode: "GBP",
+    });
 
     // act
     render(<AccountTable />);
@@ -18,10 +24,10 @@ describe("AccountTable", () => {
     const columnHeaders = screen.getAllByRole("columnheader");
 
     expect(columnHeaders[0]).toHaveTextContent("Account Name");
-    expect(columnHeaders[1]).toHaveTextContent("Max Balance 2023");
-    expect(columnHeaders[2]).toHaveTextContent("Max Balance 2024");
-    expect(columnHeaders[3]).toHaveTextContent("Max Balance 2025");
-    expect(columnHeaders[4]).toHaveTextContent("Max Balance 2026");
+    expect(columnHeaders[1]).toHaveTextContent("Max Balance 2023 (GBP)");
+    expect(columnHeaders[2]).toHaveTextContent("Max Balance 2024 (GBP)");
+    expect(columnHeaders[3]).toHaveTextContent("Max Balance 2025 (GBP)");
+    expect(columnHeaders[4]).toHaveTextContent("Max Balance 2026 (GBP)");
 
     const rows = screen.getAllByRole("row");
     // First account: Wealthsimple_Checking_Account
@@ -30,7 +36,7 @@ describe("AccountTable", () => {
     expect(firstAccountCells[0]).toHaveTextContent(
       "Wealthsimple_Checking_Account",
     );
-    expect(firstAccountCells[1]).toHaveTextContent("-"); // No max balance for 2023
+    expect(firstAccountCells[1]).toHaveTextContent("-"); // 2023 predates first transaction (2024)
     expect(firstAccountCells[2]).toHaveTextContent("0"); // 2024 max balance
     expect(firstAccountCells[3]).toHaveTextContent("3500"); // 2025 max balance
     expect(firstAccountCells[4]).toHaveTextContent("3000"); // 2026 max balance
@@ -42,6 +48,27 @@ describe("AccountTable", () => {
     expect(secondAccountCells[1]).toHaveTextContent("2000"); // 2023 max balance
     expect(secondAccountCells[2]).toHaveTextContent("2500"); // 2024 max balance
     expect(secondAccountCells[3]).toHaveTextContent("2200"); // 2025 max balance
-    expect(secondAccountCells[4]).toHaveTextContent("-"); // No max balance for 2026
+    expect(secondAccountCells[4]).toHaveTextContent("2200"); // 2026 carries forward 2025 year-end balance
+
+    // Account names render as visually-distinct hyperlinks so users see the affordance.
+    const firstAccountLink = within(firstAccountRow).getByRole("link", {
+      name: "Wealthsimple_Checking_Account",
+    });
+    expect(firstAccountLink).toHaveClass("text-blue-600");
+    expect(firstAccountLink).toHaveClass("underline");
+  });
+
+  it("omits the currency suffix when the budget currency is unknown", async () => {
+    vi.mocked(useSelectedAccounts).mockReturnValue(mockSelectedAccounts);
+    vi.mocked(useBudgetState).mockReturnValue({
+      defaultBudgetId: "",
+      defaultBudgetCurrencyIsoCode: "",
+    });
+
+    render(<AccountTable />);
+
+    const columnHeaders = screen.getAllByRole("columnheader");
+    expect(columnHeaders[1]).toHaveTextContent("Max Balance 2023");
+    expect(columnHeaders[1].textContent).not.toContain("(");
   });
 });

--- a/components/AccountTable.tsx
+++ b/components/AccountTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useSelectedAccounts } from "@/contexts/accountsContext";
+import { useBudgetState } from "@/contexts/budgetContext";
 import Caption from "@/design-system/table/Caption";
 import { FontWeight } from "@/design-system/table/enums";
 import Table from "@/design-system/table/Table";
@@ -10,10 +11,12 @@ import TableHeader from "@/design-system/table/TableHeader";
 import TableHeaderCell from "@/design-system/table/TableHeaderCell";
 import TableRow from "@/design-system/table/TableRow";
 import formatAmount from "@/formatters/formatAmount";
+import getCarryForwardBalance from "@/utility-functions/getCarryForwardBalance";
 import Link from "next/link";
 
 export default function AccountTable() {
   const selectedAccounts = useSelectedAccounts();
+  const { defaultBudgetCurrencyIsoCode } = useBudgetState();
 
   if (selectedAccounts.length === 0) {
     return null;
@@ -25,6 +28,9 @@ export default function AccountTable() {
   );
   const uniqueYears = Array.from(new Set(allYearsFromAccounts));
   const sortedYears = uniqueYears.sort((a, b) => Number(a) - Number(b));
+  const currencySuffix = defaultBudgetCurrencyIsoCode
+    ? ` (${defaultBudgetCurrencyIsoCode})`
+    : "";
 
   return (
     <Table>
@@ -33,7 +39,10 @@ export default function AccountTable() {
         <TableRow>
           <TableHeaderCell>Account Name</TableHeaderCell>
           {sortedYears.map((year) => (
-            <TableHeaderCell key={year}>Max Balance {year}</TableHeaderCell>
+            <TableHeaderCell key={year}>
+              Max Balance {year}
+              {currencySuffix}
+            </TableHeaderCell>
           ))}
         </TableRow>
       </TableHeader>
@@ -41,13 +50,27 @@ export default function AccountTable() {
         {selectedAccounts.map((account) => (
           <TableRow key={account.id}>
             <TableBodyCell fontWeight={FontWeight.Medium}>
-              <Link href={`/account/${account.id}`}>{account.name}</Link>
+              <Link
+                href={`/account/${account.id}`}
+                className="text-blue-600 underline hover:text-blue-800"
+              >
+                {account.name}
+              </Link>
             </TableBodyCell>
-            {sortedYears.map((year) => (
-              <TableBodyCell key={year}>
-                {formatAmount(account.maxBalancesByYear?.[year]?.balance)}
-              </TableBodyCell>
-            ))}
+            {sortedYears.map((year) => {
+              const directMax = account.maxBalancesByYear?.[year]?.balance;
+              const balance =
+                directMax ??
+                getCarryForwardBalance(
+                  account.transactionsWithBalances,
+                  year,
+                );
+              return (
+                <TableBodyCell key={year}>
+                  {formatAmount(balance)}
+                </TableBodyCell>
+              );
+            })}
           </TableRow>
         ))}
       </TableBody>

--- a/components/DefaultBudgetFetcher.tsx
+++ b/components/DefaultBudgetFetcher.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { BudgetActionTypes, useBudgetDispatch } from "@/contexts/budgetContext";
-import getDefaultBudgetId from "@/utility-functions/getDefaultBudgetId";
+import getDefaultBudget from "@/utility-functions/getDefaultBudget";
 import { useEffect, useState } from "react";
 
 interface YnabError {
@@ -12,24 +12,25 @@ interface YnabError {
   };
 }
 
-export default function DefaultBudgetIdFetcher() {
+export default function DefaultBudgetFetcher() {
   const [invalidTokenError, setInvalidTokenError] = useState<YnabError | null>(
     null
   );
   const budgetDispatch = useBudgetDispatch();
   useEffect(() => {
-    const updateBudgetId = async () => {
+    const updateBudget = async () => {
       try {
-        const defaultBudgetId = await getDefaultBudgetId();
+        const { id, currencyIsoCode } = await getDefaultBudget();
         budgetDispatch({
-          type: BudgetActionTypes.DefaultBudgetIdSet,
-          defaultBudgetId,
+          type: BudgetActionTypes.DefaultBudgetSet,
+          defaultBudgetId: id,
+          defaultBudgetCurrencyIsoCode: currencyIsoCode,
         });
       } catch (e) {
         setInvalidTokenError(e as YnabError);
       }
     };
-    updateBudgetId();
+    updateBudget();
   }, [budgetDispatch]);
 
   if (invalidTokenError) {

--- a/components/TransactionTable.test.tsx
+++ b/components/TransactionTable.test.tsx
@@ -1,0 +1,47 @@
+import {
+  useAccount,
+  useAccountsDispatch,
+} from "@/contexts/accountsContext";
+import { useBudgetState } from "@/contexts/budgetContext";
+import { Account } from "@/types/Account";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import TransactionTable from "./TransactionTable";
+
+vi.mock(import("@/contexts/accountsContext"));
+vi.mock(import("@/contexts/budgetContext"));
+
+describe("TransactionTable", () => {
+  it("appends the budget currency to the Amount and Balance column headers", () => {
+    vi.mocked(useAccount).mockReturnValue(new Account("Wise EUR", "abc", true));
+    vi.mocked(useAccountsDispatch).mockReturnValue(vi.fn());
+    vi.mocked(useBudgetState).mockReturnValue({
+      defaultBudgetId: "budget-1",
+      defaultBudgetCurrencyIsoCode: "EUR",
+    });
+
+    render(<TransactionTable accountId="abc" />);
+
+    const headers = screen.getAllByRole("columnheader");
+    const headerText = headers.map((h) => h.textContent);
+    expect(headerText).toContain("Amount (EUR)");
+    expect(headerText).toContain("Balance (EUR)");
+  });
+
+  it("omits the suffix when the budget currency is unknown", () => {
+    vi.mocked(useAccount).mockReturnValue(new Account("Anon", "abc", true));
+    vi.mocked(useAccountsDispatch).mockReturnValue(vi.fn());
+    vi.mocked(useBudgetState).mockReturnValue({
+      defaultBudgetId: "",
+      defaultBudgetCurrencyIsoCode: "",
+    });
+
+    render(<TransactionTable accountId="abc" />);
+
+    const headers = screen.getAllByRole("columnheader");
+    const headerText = headers.map((h) => h.textContent);
+    expect(headerText).toContain("Amount");
+    expect(headerText).toContain("Balance");
+    headerText.forEach((text) => expect(text).not.toContain("("));
+  });
+});

--- a/components/TransactionTable.tsx
+++ b/components/TransactionTable.tsx
@@ -23,7 +23,10 @@ export default function TransactionTable({ accountId }: { accountId: string }) {
   const { transactionsWithBalances, maxBalancesByYear } = useAccount(accountId);
   const accountsDispatch = useAccountsDispatch();
 
-  const { defaultBudgetId } = useBudgetState();
+  const { defaultBudgetId, defaultBudgetCurrencyIsoCode } = useBudgetState();
+  const currencySuffix = defaultBudgetCurrencyIsoCode
+    ? ` (${defaultBudgetCurrencyIsoCode})`
+    : "";
 
   const handleClick = async () => {
     const transactions = await getTransactionsForAccount(
@@ -63,8 +66,8 @@ export default function TransactionTable({ accountId }: { accountId: string }) {
             <TableHeaderCell>Date</TableHeaderCell>
             <TableHeaderCell>Payee</TableHeaderCell>
             <TableHeaderCell>Memo</TableHeaderCell>
-            <TableHeaderCell>Amount</TableHeaderCell>
-            <TableHeaderCell>Balance</TableHeaderCell>
+            <TableHeaderCell>Amount{currencySuffix}</TableHeaderCell>
+            <TableHeaderCell>Balance{currencySuffix}</TableHeaderCell>
             <TableHeaderCell>Year of Max Balance</TableHeaderCell>
           </TableRow>
         </TableHeader>
@@ -100,8 +103,8 @@ export default function TransactionTable({ accountId }: { accountId: string }) {
             <TableHeaderCell>Date</TableHeaderCell>
             <TableHeaderCell>Payee</TableHeaderCell>
             <TableHeaderCell>Memo</TableHeaderCell>
-            <TableHeaderCell>Amount</TableHeaderCell>
-            <TableHeaderCell>Balance</TableHeaderCell>
+            <TableHeaderCell>Amount{currencySuffix}</TableHeaderCell>
+            <TableHeaderCell>Balance{currencySuffix}</TableHeaderCell>
           </TableRow>
         </TableHeader>
         <TableBody>

--- a/contexts/budgetContext.tsx
+++ b/contexts/budgetContext.tsx
@@ -13,16 +13,18 @@ import {
 
 interface State {
   defaultBudgetId: string;
+  defaultBudgetCurrencyIsoCode: string;
 }
 
 export enum BudgetActionTypes {
-  DefaultBudgetIdSet = "DefaultBudgetIdSet",
+  DefaultBudgetSet = "DefaultBudgetSet",
   StateLoadedFromStorage = "StateLoadedFromStorage",
 }
 
-interface DefaultBudgetIdSetAction extends BaseAction {
-  type: BudgetActionTypes.DefaultBudgetIdSet;
+interface DefaultBudgetSetAction extends BaseAction {
+  type: BudgetActionTypes.DefaultBudgetSet;
   defaultBudgetId: string;
+  defaultBudgetCurrencyIsoCode: string;
 }
 
 interface StateLoadedFromStorageAction extends BaseAction {
@@ -31,7 +33,7 @@ interface StateLoadedFromStorageAction extends BaseAction {
 }
 
 export type BudgetAction =
-  | DefaultBudgetIdSetAction
+  | DefaultBudgetSetAction
   | StateLoadedFromStorageAction;
 
 const StateContext = createContext<State | null>(null);
@@ -40,9 +42,10 @@ const DispatchContext = createContext<Dispatch<BudgetAction> | null>(null);
 
 function budgetReducer(state: State, action: BudgetAction): State {
   switch (action.type) {
-    case BudgetActionTypes.DefaultBudgetIdSet:
+    case BudgetActionTypes.DefaultBudgetSet:
       return {
         defaultBudgetId: action.defaultBudgetId,
+        defaultBudgetCurrencyIsoCode: action.defaultBudgetCurrencyIsoCode,
       };
     case BudgetActionTypes.StateLoadedFromStorage:
       return action.loadedState;
@@ -53,6 +56,7 @@ function budgetReducer(state: State, action: BudgetAction): State {
 
 const initialState: State = {
   defaultBudgetId: "",
+  defaultBudgetCurrencyIsoCode: "",
 };
 
 interface BudgetProviderProps {

--- a/design-system/button/Button.test.tsx
+++ b/design-system/button/Button.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import Button from "./Button";
+
+describe("Button", () => {
+  it("renders a <button> and calls onClick when no href is provided", async () => {
+    const onClick = vi.fn();
+    render(<Button onClick={onClick}>Reload transactions</Button>);
+
+    const button = screen.getByRole("button", { name: "Reload transactions" });
+    button.click();
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders an anchor with the given href when href is provided", () => {
+    render(
+      <Button href="https://app.ynab.com/oauth/authorize">
+        Authorize With YNAB
+      </Button>,
+    );
+
+    const link = screen.getByRole("link", { name: "Authorize With YNAB" });
+    expect(link).toHaveAttribute("href", "https://app.ynab.com/oauth/authorize");
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("applies the same styling whether rendered as a button or anchor", () => {
+    const { rerender } = render(<Button onClick={() => {}}>Click</Button>);
+    const buttonClasses = screen.getByRole("button").className;
+
+    rerender(<Button href="/somewhere">Click</Button>);
+    const anchorClasses = screen.getByRole("link").className;
+
+    expect(anchorClasses).toBe(buttonClasses);
+  });
+});

--- a/design-system/button/Button.tsx
+++ b/design-system/button/Button.tsx
@@ -1,14 +1,22 @@
 interface ButtonProps {
   children: React.ReactNode;
   onClick?: () => void;
+  href?: string;
 }
 
-export default function Button({ children, onClick }: ButtonProps) {
+const buttonClassName =
+  "inline-flex items-center justify-center font-medium text-sm py-2 px-4 bg-primary text-primary-foreground rounded-md cursor-pointer";
+
+export default function Button({ children, onClick, href }: ButtonProps) {
+  if (href) {
+    return (
+      <a href={href} className={buttonClassName}>
+        {children}
+      </a>
+    );
+  }
   return (
-    <button
-      onClick={onClick}
-      className="inline-flex items-center justify-center font-medium text-sm py-2 px-4 bg-primary text-primary-foreground rounded-md cursor-pointer"
-    >
+    <button onClick={onClick} className={buttonClassName}>
       {children}
     </button>
   );

--- a/services/ynab-service/ynabService.test.ts
+++ b/services/ynab-service/ynabService.test.ts
@@ -57,24 +57,39 @@ describe("YnabService", () => {
       );
     });
   });
-  describe("getDefaultBudgetId", () => {
-    test("gets the user's default budget id", async () => {
+  describe("getDefaultBudget", () => {
+    test("returns the default budget's id and currency iso code", async () => {
       // arrange
       const testYnabToken = "test-ynab-token";
       const ynabService = new YnabService(testYnabToken);
       const mockDefaultBudgetId = "mock default budget id";
       mockGetBudgets.mockResolvedValueOnce({
         data: {
-          default_budget: { id: mockDefaultBudgetId },
+          default_budget: {
+            id: mockDefaultBudgetId,
+            currency_format: { iso_code: "GBP" },
+          },
         },
       });
 
       // act
-      const actualDefaultBudgetId = await ynabService.getDefaultBudgetId();
+      const actualDefaultBudget = await ynabService.getDefaultBudget();
 
       // assert
-      expect(actualDefaultBudgetId).toEqual(mockDefaultBudgetId);
+      expect(actualDefaultBudget).toEqual({
+        id: mockDefaultBudgetId,
+        currencyIsoCode: "GBP",
+      });
       expect(mockGetBudgets).toHaveBeenCalled();
+    });
+
+    test("falls back to empty strings when no default budget is set", async () => {
+      const ynabService = new YnabService("test-ynab-token");
+      mockGetBudgets.mockResolvedValueOnce({ data: {} });
+
+      const actualDefaultBudget = await ynabService.getDefaultBudget();
+
+      expect(actualDefaultBudget).toEqual({ id: "", currencyIsoCode: "" });
     });
   });
 });

--- a/services/ynab-service/ynabService.ts
+++ b/services/ynab-service/ynabService.ts
@@ -17,9 +17,13 @@ export default class YnabService {
     return accountResponse.data.accounts;
   }
 
-  async getDefaultBudgetId() {
+  async getDefaultBudget() {
     const budgetResponse = await this.ynabApi.budgets.getBudgets();
-    return budgetResponse.data.default_budget?.id ?? "";
+    const defaultBudget = budgetResponse.data.default_budget;
+    return {
+      id: defaultBudget?.id ?? "",
+      currencyIsoCode: defaultBudget?.currency_format?.iso_code ?? "",
+    };
   }
 
   async getAccountTransactions(ynabBudgetId: string, accountId: string) {

--- a/utility-functions/getCarryForwardBalance.test.ts
+++ b/utility-functions/getCarryForwardBalance.test.ts
@@ -1,0 +1,70 @@
+import { TransactionWithBalance } from "@/types/TransactionWithBalance";
+import { describe, expect, it } from "vitest";
+import getCarryForwardBalance from "./getCarryForwardBalance";
+
+const transactions: TransactionWithBalance[] = [
+  {
+    id: "1",
+    date: "2023-03-15",
+    amount: 2000000,
+    memo: "",
+    payeeName: "Deposit",
+    balance: 2000000,
+  },
+  {
+    id: "2",
+    date: "2024-04-20",
+    amount: 500000,
+    memo: "",
+    payeeName: "Deposit",
+    balance: 2500000,
+  },
+  {
+    id: "3",
+    date: "2025-06-10",
+    amount: -300000,
+    memo: "",
+    payeeName: "Withdrawal",
+    balance: 2200000,
+  },
+];
+
+describe("getCarryForwardBalance", () => {
+  it("returns the prior year-end balance for a dormant year after the account's first transaction", () => {
+    expect(getCarryForwardBalance(transactions, "2026")).toBe(2200000);
+  });
+
+  it("uses the most recent in-or-before-year balance when intermediate years are dormant", () => {
+    const sparse: TransactionWithBalance[] = [
+      {
+        id: "1",
+        date: "2020-01-01",
+        amount: 1000000,
+        memo: "",
+        payeeName: "",
+        balance: 1000000,
+      },
+      {
+        id: "2",
+        date: "2024-01-01",
+        amount: 500000,
+        memo: "",
+        payeeName: "",
+        balance: 1500000,
+      },
+    ];
+    expect(getCarryForwardBalance(sparse, "2022")).toBe(1000000);
+  });
+
+  it("returns the year's own latest balance when the year has transactions", () => {
+    expect(getCarryForwardBalance(transactions, "2024")).toBe(2500000);
+  });
+
+  it("returns undefined when the year predates the account's first transaction", () => {
+    expect(getCarryForwardBalance(transactions, "2022")).toBeUndefined();
+  });
+
+  it("returns undefined when there are no transactions", () => {
+    expect(getCarryForwardBalance([], "2024")).toBeUndefined();
+  });
+});

--- a/utility-functions/getCarryForwardBalance.ts
+++ b/utility-functions/getCarryForwardBalance.ts
@@ -1,0 +1,37 @@
+import { TransactionWithBalance } from "@/types/TransactionWithBalance";
+
+/**
+ * Returns the account's balance as of the end of the given year, using the
+ * latest transaction with a date in or before that year. Used to render an
+ * FBAR max balance for a year in which the account had no transactions —
+ * an open account dormant for a year still holds its prior year-end balance.
+ *
+ * Returns undefined when the year predates the account's first transaction,
+ * since we can't claim a balance for a year before any data exists.
+ *
+ * Assumes `transactionsWithBalances` is sorted ascending by date.
+ */
+export default function getCarryForwardBalance(
+  transactionsWithBalances: TransactionWithBalance[],
+  year: string,
+): number | undefined {
+  if (transactionsWithBalances.length === 0) {
+    return undefined;
+  }
+
+  const firstYear = transactionsWithBalances[0].date.split("-")[0];
+  if (year < firstYear) {
+    return undefined;
+  }
+
+  let lastBalance: number | undefined = undefined;
+  for (const transaction of transactionsWithBalances) {
+    const transactionYear = transaction.date.split("-")[0];
+    if (transactionYear <= year) {
+      lastBalance = transaction.balance;
+    } else {
+      break;
+    }
+  }
+  return lastBalance;
+}

--- a/utility-functions/getDefaultBudget.ts
+++ b/utility-functions/getDefaultBudget.ts
@@ -1,9 +1,8 @@
 import { TokenManager } from "@/services/tokenManager";
 import YnabService from "@/services/ynab-service/ynabService";
 
-export default async function getDefaultBudgetId() {
+export default async function getDefaultBudget() {
   const token = TokenManager.getToken();
   const ynabService = new YnabService(token);
-  const defaultBudgetId = await ynabService.getDefaultBudgetId();
-  return defaultBudgetId;
+  return ynabService.getDefaultBudget();
 }


### PR DESCRIPTION
Hey Brian, thanks for creating the YNAB FBAR calculator. While using it I noticed two material errors that give the wrong results which are serious. This pull request fixes those errors and has some minor UX clean up as well. I have been building software for 25 years and am using Claude Code to manage these changes.

The first bug is for open accounts that did not have any transactions within a year, it assumes zero balance rather than carrying forward the existing balance into the next year.

The second bug is more subtle in that the tool appears to only look at end of day balances, and it missed an account I had that received in EUR a large payment (Wise account), which was converted into GBP in the same day and thus a different Wise account and YNAB budget, and then sent to my main HSBC GBP account in the same day. So it wrongly concluded that my Wise account max balance was much lower since it missed this transaction which was the largest balance of the year for Wise. Big problem to miss this.

I have already corrected and filed my 2025 FBAR, but other expats may still want to use your app this year. Hope this helps them get the correct summary amounts. Claude will summarize the PR below.

Thanks
Sean

---

## Summary

### Bug fixes (correctness)

**1. Carry-forward prior year-end balance for years with no transactions**

Previously, `AccountTable` derived year columns from `Object.keys(maxBalancesByYear)` and rendered each cell as `account.maxBalancesByYear?.[year]?.balance`. For accounts with no transactions in a given year, the cell rendered ``undefined`` (displayed as `-`), implying zero. FBAR requires the actual year-end balance for dormant years.

A new utility `utility-functions/getCarryForwardBalance.ts` walks the account's transactions and returns the most recent balance with a date in or before the target year. `AccountTable` falls back to this when ``maxBalancesByYear[year]`` is missing. Returns `undefined` when the year predates the account's first transaction (so we don't claim a balance for a period with no data).

**2. Capture intra-day balance peak**

The YNAB v1 ``TransactionDetail`` only exposes ``date`` (no timestamp) and the API does not document a sort order for same-date transactions. The previous implementation walked the array as returned, so when an inflow and an equal outflow shared a date the running balance could read ``-5000 -> 0`` and miss the day's ``5000`` peak.

`calculation-functions/getTransactionsWithBalances.ts` now sorts ascending by date; on a same-date tie it places inflows before outflows. The day's peak is captured in a transaction's post-balance, which the FBAR Line Item Filing Instructions (Step 1) explicitly treat as a *"reasonable approximation of the greatest value of currency or nonmonetary assets in the account during the calendar year"*.

### UX clarifications

- **Currency labels** — the budget's ISO currency code (e.g. `GBP`) is fetched once via the renamed `ynabService.getDefaultBudget()` and surfaced in:
  - Home page max-balance column headers: `Max Balance 2024 (GBP)`
  - Account detail heading: `Account Name (GBP) - Details`
  - Transactions table headers: `Amount (GBP)`, `Balance (GBP)`
  - Suffix is silently dropped if currency is unknown.
- **Hyperlink affordance** — account names on the Home page render as standard hyperlinks (`text-blue-600 underline hover:text-blue-800`) so the click target is visible. Plain text styling keeps copy/paste clean for users dropping results into a spreadsheet.
- **Authorize button** — "Authorize With YNAB" on the Home page now uses the existing `Button` design-system component (matches the "Reload transactions" button). Same-tab navigation preserved. ``Button`` was minimally extended to render as ``<a>`` when given an ``href`` prop.

### Tests

Behavioral tests added or updated for every change. **22 tests across 9 files; typecheck and lint clean.**

| File | Coverage |
|---|---|
| ``calculation-functions/getTransactionsWithBalances.test.ts`` (new) | Chronological sort, intra-day Wise scenario, input-not-mutated invariant. |
| ``utility-functions/getCarryForwardBalance.test.ts`` (new) | Dormant year, gap year, year with txns, year predating first txn, empty input. |
| ``design-system/button/Button.test.tsx`` (new) | ``<button>`` w/ onClick path, ``<a>`` w/ href path, style parity between the two. |
| ``components/TransactionTable.test.tsx`` (new) | Currency suffix on Amount/Balance headers; suffix omitted when currency unknown. |
| ``components/AccountTable.test.tsx`` (modified) | Carry-forward expectation for the dormant-year case, currency suffix on column headers, hyperlink classes asserted. |
| ``services/ynab-service/ynabService.test.ts`` (modified) | ``getDefaultBudget`` returns ``{ id, currencyIsoCode }``; falls back to empty strings when no default budget is set. |

### File renames (single concept change)

- ``services/ynab-service/ynabService.ts``: ``getDefaultBudgetId()`` -> ``getDefaultBudget()`` returning ``{ id, currencyIsoCode }`` (one ``getBudgets()`` call, no extra API roundtrip).
- ``utility-functions/getDefaultBudgetId.ts`` -> ``utility-functions/getDefaultBudget.ts``
- ``components/DefaultBudgetIdFetcher.tsx`` -> ``components/DefaultBudgetFetcher.tsx``
- ``contexts/budgetContext.tsx``: state adds ``defaultBudgetCurrencyIsoCode``; action ``DefaultBudgetIdSet`` -> ``DefaultBudgetSet``.

### References

- FBAR Line Item Filing Instructions (FinCEN, Jan 2017 v1.4): https://www.fincen.gov/sites/default/files/shared/FBAR%20Line%20Item%20Filing%20Instructions.pdf
- YNAB API v1: https://api.ynab.com/v1 (TransactionDetail schema confirmed in installed SDK ``ynab@2.9.0`` — no running balance field, same-date order undocumented)
- Treasury Reporting Rates of Exchange API: https://fiscaldata.treasury.gov/datasets/treasury-reporting-rates-exchange/ (relevant for future multi-currency aggregation work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)